### PR TITLE
Adicionando introsort com heap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ BINARY?=dummy\
 				systemqsort\
 				introsortquickmerge\
 				introsortquickmergelongjmp\
+				introsortquickheaplongjmp\
 				cppsort\
 				pqsortsimple\
 				heapsort
@@ -73,6 +74,9 @@ introsortquickmerge: main.c introsortquickmerge.c separa.c insertionsort.c merge
 	gcc -D__$@__ $(CFLAGS) $^ -o $@ -lm
 
 introsortquickmergelongjmp: main.c introsortquickmergelongjmp.c separa.c insertionsort.c mergesort.c
+	gcc -D__$@__ $(CFLAGS) $^ -o $@ -lm
+
+introsortquickheaplongjmp: main.c introsortquickheaplongjmp.c separa.c insertionsort.c heapsort.c priority-queue.c
 	gcc -D__$@__ $(CFLAGS) $^ -o $@ -lm
 
 pqsortsimple: main.c pqsortsimple.c priority-queue.c

--- a/introsortquickheaplongjmp.c
+++ b/introsortquickheaplongjmp.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <math.h>
+#include <setjmp.h>
+#include "introsortquickheaplongjmp.h"
+#include "ordenacaomacros.h"
+#include "insertionsort.h"
+#include "heapsort.h"
+#include "separa.h"
+
+int trapstop=0;
+int trapsize=0;
+jmp_buf env;
+static void quicksortM3(Item *V,int l, int r,int rec)
+{
+  if (r-l<=32) return;
+
+  if(rec==0)
+  {
+    trapstop=1;
+    longjmp(env,1);
+    return;
+  }
+
+  exch(V[(l+r)/2],V[r-1]);
+  cmpexch(V[l],V[r-1]);
+  cmpexch(V[l],V[r]);
+  cmpexch(V[r-1],V[r]);
+
+
+  int j=separa(V,l+1,r-1);
+  quicksortM3(V,l,j-1,rec-1);
+  quicksortM3(V,j+1,r,rec-1);
+}
+
+void introsortquickheaplongjmp(Item *V,int l,int r)
+{
+  trapsize=2*((int)log2((double)(r-l+1)));
+  setjmp(env);
+  if(trapstop==0)
+    quicksortM3(V,l,r,trapsize);
+
+  if(trapstop==1)
+  {
+    fprintf(stderr,"trap/");
+    heapsort(V,l,r);
+  }
+  else
+    insertionsort(V,l,r);
+}

--- a/introsortquickheaplongjmp.h
+++ b/introsortquickheaplongjmp.h
@@ -1,0 +1,11 @@
+#ifndef __introsortquickheapLONGJMPH__
+#define __introsortquickheapLONGJMPH__
+#include "ordenacaomacros.h"
+
+void introsortquickheaplongjmp(Item *V, int l, int r);
+
+#ifdef __introsortquickheaplongjmponly__
+#define sort(v,l,r) introsortquickheaplongjmp(v,l,r)
+#endif
+
+#endif

--- a/main.h
+++ b/main.h
@@ -66,6 +66,10 @@
 #define __introsortquickmergelongjmponly__
 #include "introsortquickmergelongjmp.h"
 
+#elif defined(__introsortquickheaplongjmp__)
+#define __introsortquickheaplongjmponly__
+#include "introsortquickheaplongjmp.h"
+
 #elif defined(__systemqsort__)
 #define __systemqsortonly__
 #include "systemqsort.h"


### PR DESCRIPTION
Adição do introsortquickheaplongjmp ao benchmark utilizando os algorítmos quicksort, heapsort e insertionsort.

Compilando o arquivo
```bash
BINARY="introsortquickheaplongjmp" make time.aleatorio time.muitosrepetidos time.ordenado time.quaseordenado time.reverso
```

Execução dos testes
```bash
--- time.aleatorio ---
# introsortquickheaplongjmp
 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.01 0.02 0.05 0.09 0.20
--- time.muitosrepetidos ---
# introsortquickheaplongjmp
 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.01 0.01 0.03 0.08 0.16
--- time.ordenado ---
# introsortquickheaplongjmp
 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.01 0.03 0.07 0.14
--- time.quaseordenado ---
# introsortquickheaplongjmp
 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.01 0.03 0.07 0.14
--- time.reverso ---
# introsortquickheaplongjmp
 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.01 0.02 0.03 0.07 0.16
```